### PR TITLE
Fix incorrect reference to _canvasElement

### DIFF
--- a/src/webcam-easy.js
+++ b/src/webcam-easy.js
@@ -174,7 +174,7 @@ export default class Webcam {
         }
         context.clearRect(0, 0, this._canvasElement.width, this._canvasElement.height);
         context.drawImage(this._webcamElement, 0, 0, this._canvasElement.width, this._canvasElement.height);
-        let data = canvas.toDataURL('image/png');
+        let data = this._canvasElement.toDataURL('image/png');
         return data;
       }
       else{


### PR DESCRIPTION
This was raising an error on `snap()`