### PR TITLE
Fix spelling of enviroment

### DIFF
--- a/dist/webcam-easy.js
+++ b/dist/webcam-easy.js
@@ -66,7 +66,7 @@ class Webcam {
   selectCamera(){
     for(let webcam of this._webcamList){
       if(   (this._facingMode=='user' && webcam.label.toLowerCase().includes('front'))
-        ||  (this._facingMode=='enviroment' && webcam.label.toLowerCase().includes('back'))
+        ||  (this._facingMode=='environment' && webcam.label.toLowerCase().includes('back'))
       )
       {
         this._selectedDeviceId = webcam.deviceId;
@@ -77,7 +77,7 @@ class Webcam {
 
   /* Change Facing mode and selected camera */ 
   flip(){
-    this._facingMode = (this._facingMode == 'user')? 'enviroment': 'user';
+    this._facingMode = (this._facingMode == 'user')? 'environment': 'user';
     this._webcamElement.style.transform = "";
     this.selectCamera();  
   }


### PR DESCRIPTION
`environment` was spelled incorrectly as `enviroment` this causes calls to `getVideoConstraints` to not work as intended.

This code has been an absolute life saver for me, thank you very much.